### PR TITLE
Fixed typo in Linkwitz-Riley filters causing self-oscillation; fixed …

### DIFF
--- a/src/so_linkwitz_riley_hpf.cpp
+++ b/src/so_linkwitz_riley_hpf.cpp
@@ -24,11 +24,11 @@ F_SIZE SO_LINKWITZ_RILEY_HPF::filter(F_SIZE sample)
 {
 	F_SIZE xn = sample;
 	F_SIZE yn = m_coeffs.a0*xn + m_coeffs.a1*m_xnz1 + m_coeffs.a2*m_xnz2
-		- m_coeffs.b1*m_ynz1 - m_coeffs.b2*m_xnz2;
+		- m_coeffs.b1*m_ynz1 - m_coeffs.b2*m_ynz2;
 
 	m_xnz2 = m_xnz1;
 	m_xnz1 = xn;
-	m_xnz2 = m_ynz1;
+	m_ynz2 = m_ynz1;
 	m_ynz1 = yn;
 
 	return(yn);

--- a/src/so_linkwitz_riley_hpf.h
+++ b/src/so_linkwitz_riley_hpf.h
@@ -19,6 +19,6 @@ public:
 	F_SIZE filter(F_SIZE sample);
 
 private:
-	F_SIZE m_xnz1, m_xnz2, m_ynz1, m_ynz2;
+	F_SIZE m_xnz1 = 0, m_xnz2 = 0, m_ynz1 = 0, m_ynz2 = 0;
 	tp_coeffs m_coeffs;
 };

--- a/src/so_linkwitz_riley_lpf.cpp
+++ b/src/so_linkwitz_riley_lpf.cpp
@@ -24,11 +24,11 @@ F_SIZE SO_LINKWITZ_RILEY_BPF::filter(F_SIZE sample)
 {
 	F_SIZE xn = sample;
 	F_SIZE yn = m_coeffs.a0*xn + m_coeffs.a1*m_xnz1 + m_coeffs.a2*m_xnz2
-		- m_coeffs.b1*m_ynz1 - m_coeffs.b2*m_xnz2;
+		- m_coeffs.b1*m_ynz1 - m_coeffs.b2*m_ynz2;
 
 	m_xnz2 = m_xnz1;
 	m_xnz1 = xn;
-	m_xnz2 = m_ynz1;
+	m_ynz2 = m_ynz1;
 	m_ynz1 = yn;
 
 	return(yn);

--- a/src/so_linkwitz_riley_lpf.h
+++ b/src/so_linkwitz_riley_lpf.h
@@ -19,6 +19,6 @@ public:
 	F_SIZE filter(F_SIZE sample);
 
 private:
-	F_SIZE m_xnz1, m_xnz2, m_ynz1, m_ynz2;
+	F_SIZE m_xnz1 = 0, m_xnz2 = 0, m_ynz1 = 0, m_ynz2 = 0;
 	tp_coeffs m_coeffs;
 };


### PR DESCRIPTION
…sample buffer being not initialized before being referenced.