### PR TITLE
avoid macro names conflict

### DIFF
--- a/lib/filter_common.h
+++ b/lib/filter_common.h
@@ -7,14 +7,14 @@
 #define COEFF_SIZE_DOUBLE
 //#define COEFF_SIZE_FLOAT
 
-#ifndef pi
-#define pi  3.1415926535897932384626433832795
+#ifndef dcf_pi
+#define dcf_pi  3.1415926535897932384626433832795
 #endif
 
-#ifndef sqrt2
-#define sqrt2	(2.0 * 0.707106781186547524401)
+#ifndef dcf_sqrt2
+#define dcf_sqrt2	(2.0 * 0.707106781186547524401)
 #endif
 
-#ifndef sqrt2over2
-#define sqrt2over2  0.707106781186547524401
+#ifndef dcf_sqrt2over2
+#define dcf_sqrt2over2  0.707106781186547524401
 #endif

--- a/lib/fo_apf.h
+++ b/lib/fo_apf.h
@@ -11,7 +11,7 @@ class FO_APF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs = 44100)
     {
-        coef_size_t a = (tan(pi*fc / fs) - 1.0) / (tan(pi*fc / fs) + 1.0);
+        coef_size_t a = (tan(dcf_pi*fc / fs) - 1.0) / (tan(dcf_pi*fc / fs) + 1.0);
         m_coeffs.a0 = a;
         m_coeffs.a1 = 1.0;
         m_coeffs.a2 = 0.0;

--- a/lib/fo_hpf.h
+++ b/lib/fo_hpf.h
@@ -9,7 +9,7 @@ class FO_HPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t th = 2.0 * pi * fc / fs;
+        coef_size_t th = 2.0 * dcf_pi * fc / fs;
         coef_size_t g = cos(th) / (1.0 + sin(th));
         m_coeffs.a0 = (1.0 + g) / 2.0;
         m_coeffs.a1 = -((1.0 + g) / 2.0);

--- a/lib/fo_lpf.h
+++ b/lib/fo_lpf.h
@@ -9,7 +9,7 @@ class FO_LPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t th = 2.0 * pi * fc / fs;
+        coef_size_t th = 2.0 * dcf_pi * fc / fs;
         coef_size_t g = cos(th) / (1.0 + sin(th));
         m_coeffs.a0 = (1.0 - g) / 2.0;
         m_coeffs.a1 = (1.0 - g) / 2.0;

--- a/lib/fo_shelving_high.h
+++ b/lib/fo_shelving_high.h
@@ -16,7 +16,7 @@ class FO_SHELVING_HIGH : public BiquadModified {
 public:
 	tp_coeffs& calculate_coeffs(float gain_db, int fc, int fs)
 	{
-		coef_size_t th = 2.0 * pi * fc / fs;
+		coef_size_t th = 2.0 * dcf_pi * fc / fs;
 		coef_size_t m = pow(10.0, gain_db / 20.0);
 		coef_size_t b = (1.0 + m) / 4.0;
 		coef_size_t d = b * tan(th / 2.0);

--- a/lib/fo_shelving_low.h
+++ b/lib/fo_shelving_low.h
@@ -16,7 +16,7 @@ class FO_SHELVING_LOW : public BiquadModified {
 public:
 	tp_coeffs& calculate_coeffs(float gain_db, int fc, int fs)
 	{
-		coef_size_t th = 2.0 * pi * fc / fs;
+		coef_size_t th = 2.0 * dcf_pi * fc / fs;
 		coef_size_t m = pow(10.0, gain_db / 20.0);
 		coef_size_t b = 4.0 / (1.0 + m);
 		coef_size_t d = b * tan(th / 2.0);

--- a/lib/so_apf.h
+++ b/lib/so_apf.h
@@ -12,8 +12,8 @@ class SO_APF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float Q, int fs)
     {
-        coef_size_t a = (tan(pi*Q / fs) - 1.0) / (tan(pi*Q / fs) + 1.0);
-        coef_size_t b = -cos(pi*Q / fs);
+        coef_size_t a = (tan(dcf_pi*Q / fs) - 1.0) / (tan(dcf_pi*Q / fs) + 1.0);
+        coef_size_t b = -cos(dcf_pi*Q / fs);
         m_coeffs.a0 = -a;
         m_coeffs.a1 = b*(1.0 - a);
         m_coeffs.a2 = 1.0;

--- a/lib/so_bpf.h
+++ b/lib/so_bpf.h
@@ -12,7 +12,7 @@ class SO_BPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float Q, int fc, int fs)
     {
-        coef_size_t w = 2.0 * pi * fc / fs;
+        coef_size_t w = 2.0 * dcf_pi * fc / fs;
         coef_size_t b = 0.5*((1.0 - tan(w / (2.0*Q))) / (1.0 + tan(w / (2.0*Q))));
         coef_size_t g = (0.5 + b)*cos(w);
         m_coeffs.a0 = 0.5 - b;

--- a/lib/so_bsf.h
+++ b/lib/so_bsf.h
@@ -12,7 +12,7 @@ class SO_BSF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float Q, int fc, int fs)
     {
-        coef_size_t w = 2.0 * pi * fc / fs;
+        coef_size_t w = 2.0 * dcf_pi * fc / fs;
         coef_size_t b = 0.5*((1.0 - tan(w / (2.0*Q))) / (1.0 + tan(w / (2.0*Q))));
         coef_size_t g = (0.5 + b)*cos(w);
         m_coeffs.a0 = 0.5 + b;

--- a/lib/so_butterworth_bpf.h
+++ b/lib/so_butterworth_bpf.h
@@ -14,8 +14,8 @@ class SO_BUTTERWORTH_BPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float bw, int fc, int fs)
     {
-        coef_size_t c = 1.0 / (tan(pi*fc*bw / fs));
-        coef_size_t d = 2.0 * cos(2.0 * pi * fc / fs);
+        coef_size_t c = 1.0 / (tan(dcf_pi*fc*bw / fs));
+        coef_size_t d = 2.0 * cos(2.0 * dcf_pi * fc / fs);
         m_coeffs.a0 = 1.0 / (1.0 + c);
         m_coeffs.a1 = 0.0;
         m_coeffs.a2 = - m_coeffs.a0;

--- a/lib/so_butterworth_bsf.h
+++ b/lib/so_butterworth_bsf.h
@@ -14,8 +14,8 @@ class SO_BUTTERWORTH_BSF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float bw, int fc, int fs)
     {
-        coef_size_t c = tan(pi*fc*bw / fs);
-        coef_size_t d = 2.0 * cos(2.0 * pi * fc / fs);
+        coef_size_t c = tan(dcf_pi*fc*bw / fs);
+        coef_size_t d = 2.0 * cos(2.0 * dcf_pi * fc / fs);
         m_coeffs.a0 = 1.0 / (1.0 + c);
         m_coeffs.a1 = -m_coeffs.a0 * d;
         m_coeffs.a2 = m_coeffs.a0;

--- a/lib/so_butterworth_hpf.h
+++ b/lib/so_butterworth_hpf.h
@@ -14,12 +14,12 @@ class SO_BUTTERWORTH_HPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t c = tan(pi*fc / fs);
-        m_coeffs.a0 = 1.0 / (1.0 + sqrt2*c + pow(c, 2.0));
+        coef_size_t c = tan(dcf_pi*fc / fs);
+        m_coeffs.a0 = 1.0 / (1.0 + dcf_sqrt2*c + pow(c, 2.0));
         m_coeffs.a1 = -2.0 * m_coeffs.a0;
         m_coeffs.a2 = m_coeffs.a0;
         m_coeffs.b1 = 2.0 * m_coeffs.a0*(pow(c, 2.0) - 1.0);
-        m_coeffs.b2 = m_coeffs.a0 * (1.0 - sqrt2*c + pow(c, 2.0));
+        m_coeffs.b2 = m_coeffs.a0 * (1.0 - dcf_sqrt2*c + pow(c, 2.0));
         return(std::ref(m_coeffs));
     }
 };

--- a/lib/so_butterworth_lpf.h
+++ b/lib/so_butterworth_lpf.h
@@ -15,12 +15,12 @@ class SO_BUTTERWORTH_LPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t c = 1.0 / (std::tan(pi*fc / fs));
-        m_coeffs.a0 = 1.0 / (1.0 + sqrt2*c + std::pow(c, 2.0) );
+        coef_size_t c = 1.0 / (std::tan(dcf_pi*fc / fs));
+        m_coeffs.a0 = 1.0 / (1.0 + dcf_sqrt2*c + std::pow(c, 2.0) );
         m_coeffs.a1 = 2.0 * m_coeffs.a0;
         m_coeffs.a2 = m_coeffs.a0;
         m_coeffs.b1 = 2.0 * m_coeffs.a0*(1.0 - std::pow(c, 2.0));
-        m_coeffs.b2 = m_coeffs.a0 * (1.0 - sqrt2*c + std::pow(c, 2.0) );
+        m_coeffs.b2 = m_coeffs.a0 * (1.0 - dcf_sqrt2*c + std::pow(c, 2.0) );
         return(std::ref(m_coeffs));
     }
 };

--- a/lib/so_hpf.h
+++ b/lib/so_hpf.h
@@ -12,7 +12,7 @@ class SO_HPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float Q, int fc, int fs)
     {
-        coef_size_t w = 2.0 * pi * fc / fs;
+        coef_size_t w = 2.0 * dcf_pi * fc / fs;
         coef_size_t d = 1.0 / Q;
         coef_size_t b = 0.5*(1.0 - (d / 2)*sin(w)) / (1.0 + (d / 2.0)*sin(w));
         coef_size_t g = (0.5 + b)*cos(w);

--- a/lib/so_linkwitz_riley_hpf.h
+++ b/lib/so_linkwitz_riley_hpf.h
@@ -15,8 +15,8 @@ class SO_LINKWITZ_RILEY_HPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t th = pi * fc / fs;
-        coef_size_t Wc = pi * fc;
+        coef_size_t th = dcf_pi * fc / fs;
+        coef_size_t Wc = dcf_pi * fc;
         coef_size_t k = Wc / tan(th);
 
         coef_size_t d = pow(k, 2.0) + pow(Wc, 2.0) + 2.0 * k * Wc;

--- a/lib/so_linkwitz_riley_lpf.h
+++ b/lib/so_linkwitz_riley_lpf.h
@@ -15,8 +15,8 @@ class SO_LINKWITZ_RILEY_LPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(int fc, int fs)
     {
-        coef_size_t th = pi * fc / fs;
-        coef_size_t Wc = pi * fc;
+        coef_size_t th = dcf_pi * fc / fs;
+        coef_size_t Wc = dcf_pi * fc;
         coef_size_t k = Wc / tan(th);
 
         coef_size_t d = pow(k, 2.0) + pow(Wc, 2.0) + 2.0 * k * Wc;

--- a/lib/so_lpf.h
+++ b/lib/so_lpf.h
@@ -12,7 +12,7 @@ class SO_LPF : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float Q, int fc, int fs)
     {
-        coef_size_t w = 2.0 * pi * fc / fs;
+        coef_size_t w = 2.0 * dcf_pi * fc / fs;
         coef_size_t d = 1.0 / Q;
         coef_size_t b = 0.5*(1.0 - (d / 2)*sin(w)) / (1.0 + (d / 2.0)*sin(w));
         coef_size_t g = (0.5 + b)*cos(w);

--- a/lib/so_parametric_cq_boost.h
+++ b/lib/so_parametric_cq_boost.h
@@ -24,7 +24,7 @@ class SO_PARAMETRIC_CQ_BOOST : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float gain_db, float Q, int fc, int fs)
     {
-        coef_size_t K = 2.0 * pi * fc / fs;
+        coef_size_t K = 2.0 * dcf_pi * fc / fs;
         coef_size_t V0 = pow(10.0, gain_db / 20.0);
         coef_size_t d0 = 1.0 + K/Q + pow(K, 2.0);
         coef_size_t a = 1.0 + (V0*K)/Q + pow(K, 2.0);

--- a/lib/so_parametric_cq_cut.h
+++ b/lib/so_parametric_cq_cut.h
@@ -24,7 +24,7 @@ class SO_PARAMETRIC_CQ_CUT : public Biquad {
 public:
     tp_coeffs calculate_coeffs(float gain_db, float Q, int fc, int fs)
 	{
-        coef_size_t K = 2.0 * pi * fc / fs;
+        coef_size_t K = 2.0 * dcf_pi * fc / fs;
         coef_size_t V0 = pow(10.0, gain_db / 20.0);
         coef_size_t d0 = 1.0 + K / Q + pow(K, 2.0);
         coef_size_t e = 1.0 + K / (V0*Q) + pow(K, 2.0);

--- a/lib/so_parametric_ncq.h
+++ b/lib/so_parametric_ncq.h
@@ -24,7 +24,7 @@ class SO_PARAMETRIC_NCQ : public Biquad {
 public:
     tp_coeffs& calculate_coeffs(float gain_db, float Q, int fc, int fs)
     {
-        coef_size_t w = 2.0 * pi * fc / fs;
+        coef_size_t w = 2.0 * dcf_pi * fc / fs;
         coef_size_t m = pow(10.0, gain_db / 20.0);
         coef_size_t z = 4.0 / (1.0 + m);
         coef_size_t b = 0.5 * ((1.0 - z*tan(w / (2.0*Q)) / (1 + z*tan(w / (2.0*Q)))));


### PR DESCRIPTION
it's very likely that there is already a thing named "pi" or "sqrt2" in a codebase, and you get a "expected unqualified-id before numeric constant" error....
anyway, fixed this by adding a dcf_ prefix to these macros! ^^